### PR TITLE
feat: Create initial word games webpage structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Word Games</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <div id="game-list-pane">
+            <h2>Choose a Game</h2>
+            <ul>
+                <li data-game="hangman">Hangman</li>
+                <li data-game="scramble">Word Scramble</li>
+                <li data-game="crossword">Crossword</li>
+            </ul>
+        </div>
+        <div id="game-view-pane">
+            <p>Select a game from the left to start playing!</p>
+        </div>
+    </div>
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const gameListItems = document.querySelectorAll('#game-list-pane li');
+    const gameViewPane = document.getElementById('game-view-pane');
+
+    const gamePlaceholders = {
+        hangman: {
+            title: "Hangman",
+            description: "Guess the letters to find the hidden word. You have a limited number of incorrect guesses!"
+        },
+        scramble: {
+            title: "Word Scramble",
+            description: "Unscramble the letters to form a valid word. How many can you find?"
+        },
+        crossword: {
+            title: "Crossword",
+            description: "Fill in the words into the grid based on the given clues. Test your vocabulary!"
+        }
+    };
+
+    gameListItems.forEach(item => {
+        item.addEventListener('click', () => {
+            const gameKey = item.getAttribute('data-game');
+            const gameData = gamePlaceholders[gameKey];
+
+            if (gameData) {
+                gameViewPane.innerHTML = `
+                    <h1>${gameData.title}</h1>
+                    <p>${gameData.description}</p>
+                    <p><em>(Full game implementation coming soon!)</em></p>
+                `;
+            } else {
+                gameViewPane.innerHTML = '<p>Select a game from the left to start playing!</p>';
+            }
+        });
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,70 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-color: #f4f4f4;
+}
+
+.container {
+    display: flex;
+    width: 90%;
+    max-width: 1200px;
+    height: 80vh;
+    background-color: #fff;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+#game-list-pane {
+    width: 25%;
+    padding: 20px;
+    border-right: 1px solid #ddd;
+    background-color: #f9f9f9;
+    overflow-y: auto;
+}
+
+#game-list-pane h2 {
+    margin-top: 0;
+    color: #333;
+}
+
+#game-list-pane ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#game-list-pane li {
+    padding: 10px 15px;
+    cursor: pointer;
+    border-bottom: 1px solid #eee;
+    transition: background-color 0.3s ease;
+}
+
+#game-list-pane li:last-child {
+    border-bottom: none;
+}
+
+#game-list-pane li:hover {
+    background-color: #e0e0e0;
+    color: #000;
+}
+
+#game-view-pane {
+    width: 75%;
+    padding: 20px;
+    overflow-y: auto;
+}
+
+#game-view-pane h1 {
+    margin-top: 0;
+    color: #333;
+}
+
+#game-view-pane p {
+    color: #555;
+}


### PR DESCRIPTION
Adds the basic HTML, CSS, and JavaScript for a word games page.

The page features:
- A left pane for selecting different word games.
- A right pane to display the selected game.
- Placeholder content for three games: Hangman, Word Scramble, and Crossword.
- Basic styling for layout and interactivity.
- JavaScript to handle game selection and update the view pane with placeholder game information.

This provides the foundational structure for future game implementations.